### PR TITLE
Made virtual keyboard accept input by default. Fixes #31

### DIFF
--- a/app/src/components/Keyboard.jsx
+++ b/app/src/components/Keyboard.jsx
@@ -20,6 +20,7 @@ export class Keyboard extends React.Component{
       accepted: (...a) => this.handleChange(...a),
       canceled: (...a) => this.handleChange(...a),
       usePreview: false,
+      autoAccept: true,
       layout: this.props.layout || 'qwerty-no' 
     });
   }


### PR DESCRIPTION
When clicking outside the keyboard the input it accepted by default.

Fixes #31.