### PR TITLE
Make tabs be as wide as column width allows them to be

### DIFF
--- a/app/src/components/views/shop.jsx
+++ b/app/src/components/views/shop.jsx
@@ -237,7 +237,14 @@ export class ShopView extends React.Component {
         );
       }
       tabs.push(
-        <Tab active={defaultCategory===i} key={i} title={category.name}>
+        <Tab
+          active={defaultCategory === i}
+          key={i}
+          title={category.name}
+          // Defines tab size by finding out how many of the 12 MD columns
+          // can be used and then floor that value.
+          size={Math.floor(12 / Object.keys(categories).length)}
+        >
           <div className="catalog">
             {category.inv}
           </div>


### PR DESCRIPTION
I think it looks better if the tabs fill the whole width of the top bar, so we don't have any leftover whitespace.

Before:
![nibble_pre](https://cloud.githubusercontent.com/assets/5422571/26109420/d9401f0e-3a4f-11e7-9eb1-3262096a2985.png)

After: 
![nibble_post](https://cloud.githubusercontent.com/assets/5422571/26109550/2cded86c-3a50-11e7-9c37-c0e8c94ca9ec.png)
