### PR TITLE
Removed hover on catalog cards

### DIFF
--- a/app/assets/app.css
+++ b/app/assets/app.css
@@ -19,10 +19,6 @@ body {
   box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12), 0 3px 1px -2px rgba(0,0,0,0.2);
 }
 
-.catalogCard:hover {
-  box-shadow: 0 8px 17px 0 rgba(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19);
-}
-
 .catalogCardEmpty {
   box-shadow: none;
   cursor: inherit;


### PR DESCRIPTION
Fixes #48 by just removing the hover effect. No idea why we had one, considering the fact that there's not a whole lot of hovering going on with touch screens, which is how we use Nibble. I suppose it's some loss in interactivity when testing and so on, but the bug is really visually jarring. 
It's a quick fix, doesn't solve the underlying issue of the ghost cursor that potentially afflicts #49 