### PR TITLE
Allow form data in body

### DIFF
--- a/app/src/services/net/http.service.js
+++ b/app/src/services/net/http.service.js
@@ -79,7 +79,7 @@ export class HttpServiceProvider {
     */
     if (!r.ok) {
       // 401 Unauthorized
-      if (r.status === 401) {
+      if (r.status === 401 || r.status === 403) {
         // Add request to queue
         const resolver = new Subject();
         this.requestQueue.push({ request: req, subject: resolver, usetoken });

--- a/app/src/services/net/http.service.js
+++ b/app/src/services/net/http.service.js
@@ -95,9 +95,9 @@ export class HttpServiceProvider {
    * @param {Request} url
    * @return Observable<{}>
    */
-  request(request, clone, usetoken=true) {
+  request(request, clone, usetoken = true) {
     // Add token to request
-    if(usetoken){
+    if (usetoken) {
       request.headers.set('Authorization', `Bearer ${this.auth_token}`);
     }
     const resolver = new Subject();
@@ -110,7 +110,7 @@ export class HttpServiceProvider {
    * @param {params} {key: value}
    * @return Observable<{}>
    */
-  get(url, params, usetoken=true) {
+  get(url, params, usetoken = true) {
     let pUrl = url;
     if (params) {
       pUrl += HttpServiceProvider.urlEncode(params);

--- a/app/src/services/net/http.service.js
+++ b/app/src/services/net/http.service.js
@@ -45,7 +45,7 @@ export class HttpServiceProvider {
         client_secret: CLIENT_SECRET,
         client_id: CLIENT_ID,
         grant_type: 'client_credentials',
-      }, true)
+      }, true, true)
         .subscribe((data) => {
           this.auth_token = data.access_token;
           if (this.storage) { this.storage.setItem('auth_token', data.access_token); }
@@ -122,6 +122,10 @@ export class HttpServiceProvider {
   }
 
   static urlEncode(data) {
+    return `?${HttpServiceProvider.formEncode(data)}`;
+  }
+
+  static formEncode(data) {
     let ret = '';
     for (const key in data) {
       if (ret !== '') {
@@ -129,7 +133,7 @@ export class HttpServiceProvider {
       }
       ret += `${encodeURIComponent(key)}=${encodeURIComponent(data[key])}`;
     }
-    return `?${ret}`;
+    return `${ret}`;
   }
   /** Performs a post request
    * @param {string} url
@@ -137,7 +141,7 @@ export class HttpServiceProvider {
    * @param {boolean} urlEncoded
    * @return Observable<{}>
    */
-  post(url, body, urlEncoded, usetoken=true) {
+  post(url, body, urlEncoded, dataInBody = false, usetoken = true) {
     let pUrl = url;
     let pBody = body;
     const headers = new Headers();
@@ -145,9 +149,13 @@ export class HttpServiceProvider {
     headers.set('Content-Type', 'application/json');
 
     if (urlEncoded) {
-      pUrl += HttpServiceProvider.urlEncode(pBody);
       headers.set('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
-      pBody = null;
+      if (dataInBody) {
+        pBody = HttpServiceProvider.formEncode(pBody);
+      } else {
+        pUrl += HttpServiceProvider.urlEncode(pBody);
+        pBody = null;
+      }
     } else {
       pBody = JSON.stringify(pBody);
     }

--- a/app/src/services/net/http.service.js
+++ b/app/src/services/net/http.service.js
@@ -78,7 +78,9 @@ export class HttpServiceProvider {
       and retry
     */
     if (!r.ok) {
-      // 401 Unauthorized
+      /* 401 Unauthorized or 403 Forbidden. 403 is used by some applications to
+      indicate that the current authentication cannot access this resource.
+      This will also happen if the token is expired, as you are authenticated but it's not valid */
       if (r.status === 401 || r.status === 403) {
         // Add request to queue
         const resolver = new Subject();
@@ -122,10 +124,6 @@ export class HttpServiceProvider {
   }
 
   static urlEncode(data) {
-    return `?${HttpServiceProvider.formEncode(data)}`;
-  }
-
-  static formEncode(data) {
     let ret = '';
     for (const key in data) {
       if (ret !== '') {
@@ -150,10 +148,11 @@ export class HttpServiceProvider {
 
     if (urlEncoded) {
       headers.set('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+      const encoded = HttpServiceProvider.urlEncode(pBody);
       if (dataInBody) {
-        pBody = HttpServiceProvider.formEncode(pBody);
+        pBody = encoded;
       } else {
-        pUrl += HttpServiceProvider.urlEncode(pBody);
+        pUrl += `?${encoded}`;
         pBody = null;
       }
     } else {


### PR DESCRIPTION
Update method used for client credentials-flow to match the intended data-in-post-body.
This is required for oauthlib 3.1.0, as well as oidc-provider used by OW4