### PR TITLE
Change endpoints to use oidc at OW4

### DIFF
--- a/app/src/common/constants.example.js
+++ b/app/src/common/constants.example.js
@@ -1,6 +1,6 @@
 export const BASE = 'https://online.ntnu.no/';
 export const API_BASE = `${BASE}api/v1/`;
-export const API_AUTH = 'auth/';
+export const API_AUTH = 'openid/token';
 export const API_USERS = 'usersaldo/';
 export const API_INVENTORY = 'inventory/';
 export const API_RFID = 'rfid/';

--- a/app/src/services/net/http.service.js
+++ b/app/src/services/net/http.service.js
@@ -1,6 +1,6 @@
 import { Observable, Subject } from 'rxjs';
 
-import { API_BASE, API_AUTH, CLIENT_SECRET, CLIENT_ID } from 'common/constants';
+import { BASE, API_AUTH, CLIENT_SECRET, CLIENT_ID } from 'common/constants';
 
 export class HttpServiceProvider {
   constructor(storage) {
@@ -41,7 +41,7 @@ export class HttpServiceProvider {
     if (!this.waitingForToken) {
       this.waitingForToken = true;
       // Request new token
-      this.post(`${API_BASE}${API_AUTH}`, {
+      this.post(`${BASE}${API_AUTH}`, {
         client_secret: CLIENT_SECRET,
         client_id: CLIENT_ID,
         grant_type: 'client_credentials',
@@ -95,9 +95,9 @@ export class HttpServiceProvider {
    * @param {Request} url
    * @return Observable<{}>
    */
-  request(request, clone, usetoken=true) {
+  request(request, clone, usetoken = true) {
     // Add token to request
-    if(usetoken){
+    if (usetoken) {
       request.headers.set('Authorization', `Bearer ${this.auth_token}`);
     }
     const resolver = new Subject();
@@ -110,7 +110,7 @@ export class HttpServiceProvider {
    * @param {params} {key: value}
    * @return Observable<{}>
    */
-  get(url, params, usetoken=true) {
+  get(url, params, usetoken = true) {
     let pUrl = url;
     if (params) {
       pUrl += HttpServiceProvider.urlEncode(params);
@@ -137,7 +137,7 @@ export class HttpServiceProvider {
    * @param {boolean} urlEncoded
    * @return Observable<{}>
    */
-  post(url, body, urlEncoded, usetoken=true) {
+  post(url, body, urlEncoded, usetoken = true) {
     let pUrl = url;
     let pBody = body;
     const headers = new Headers();


### PR DESCRIPTION
# ! This is dependent on #74 

Django-oidc-provider provides oauth2-authentication as well, and can be used instead of oauth2.

**This is a breaking change**.
This requires a pull request to be merged at OW4 to use OIDC for the shop instead of Oauth